### PR TITLE
修复在Django2.x中使用的时候，json.load(f)会抛出字符集异常错误

### DIFF
--- a/TimeNormalizer.py
+++ b/TimeNormalizer.py
@@ -28,15 +28,15 @@ class TimeNormalizer:
     def init(self):
         fpath = os.path.dirname(__file__) + '/resource/reg.pkl'
         try:
-            with open(fpath, 'rb', encoding='utf-8') as f:
+            with open(fpath, 'rb') as f:
                 pattern = pickle.load(f)
         except:
-            with open(os.path.dirname(__file__) + '/resource/regex.txt', 'r', encoding='utf-8') as f:
+            with open(os.path.dirname(__file__) + '/resource/regex.txt', 'r') as f:
                 content = f.read()
             p = re.compile(content)
-            with open(fpath, 'wb', encoding='utf-8') as f:
+            with open(fpath, 'wb') as f:
                 pickle.dump(p, f)
-            with open(fpath, 'rb', encoding='utf-8') as f:
+            with open(fpath, 'rb') as f:
                 pattern = pickle.load(f)
         with open(os.path.dirname(__file__) + '/resource/holi_solar.json', 'r', encoding='utf-8') as f:
             holi_solar = json.load(f)

--- a/TimeNormalizer.py
+++ b/TimeNormalizer.py
@@ -28,19 +28,19 @@ class TimeNormalizer:
     def init(self):
         fpath = os.path.dirname(__file__) + '/resource/reg.pkl'
         try:
-            with open(fpath, 'rb') as f:
+            with open(fpath, 'rb', encoding='utf-8') as f:
                 pattern = pickle.load(f)
         except:
-            with open(os.path.dirname(__file__) + '/resource/regex.txt', 'r') as f:
+            with open(os.path.dirname(__file__) + '/resource/regex.txt', 'r', encoding='utf-8') as f:
                 content = f.read()
             p = re.compile(content)
-            with open(fpath, 'wb') as f:
+            with open(fpath, 'wb', encoding='utf-8') as f:
                 pickle.dump(p, f)
-            with open(fpath, 'rb') as f:
+            with open(fpath, 'rb', encoding='utf-8') as f:
                 pattern = pickle.load(f)
-        with open(os.path.dirname(__file__) + '/resource/holi_solar.json', 'r') as f:
+        with open(os.path.dirname(__file__) + '/resource/holi_solar.json', 'r', encoding='utf-8') as f:
             holi_solar = json.load(f)
-        with open(os.path.dirname(__file__) + '/resource/holi_lunar.json', 'r') as f:
+        with open(os.path.dirname(__file__) + '/resource/holi_lunar.json', 'r', encoding='utf-8') as f:
             holi_lunar = json.load(f)
         return pattern, holi_solar, holi_lunar
 


### PR DESCRIPTION
经过测试，在`Django2.x`中使用的时候，`json.load(f)`会抛出字符集异常错误。

此合并指定了`utf-8字符集`格式，用于解决此问题，异常如下图：

<img width="900" alt="2018-02-01 10 42 09" src="https://user-images.githubusercontent.com/9330061/35684995-6a0e28e8-07a3-11e8-92fd-d13009ee018c.png">
