### PR TITLE
Fix filter has no len

### DIFF
--- a/StringPreHandler.py
+++ b/StringPreHandler.py
@@ -131,7 +131,7 @@ class StringPreHandler:
         for m in match:
             group = m.group()
             s = group.split(u"万")
-            s = filter(None, s)
+            s = list(filter(None, s))
             num = 0
             if len(s) == 1:
                 tenthousand = int(s[0])

--- a/StringPreHandler.py
+++ b/StringPreHandler.py
@@ -43,7 +43,7 @@ class StringPreHandler:
         for m in match:
             group = m.group()
             s = group.split(u"万")
-            s = filter(None, s)
+            s = list(filter(None, s))
             num = 0
             if len(s) == 2:
                 num += cls.wordToNumber(s[0]) * 10000 + cls.wordToNumber(s[1]) * 1000
@@ -54,7 +54,7 @@ class StringPreHandler:
         for m in match:
             group = m.group()
             s = group.split(u"千")
-            s = filter(None, s)
+            s = list(filter(None, s))
             num = 0
             if len(s) == 2:
                 num += cls.wordToNumber(s[0]) * 1000 + cls.wordToNumber(s[1]) * 100
@@ -65,7 +65,7 @@ class StringPreHandler:
         for m in match:
             group = m.group()
             s = group.split(u"百")
-            s = filter(None, s)
+            s = list(filter(None, s))
             num = 0
             if len(s) == 2:
                 num += cls.wordToNumber(s[0]) * 100 + cls.wordToNumber(s[1]) * 10
@@ -99,7 +99,7 @@ class StringPreHandler:
         for m in match:
             group = m.group()
             s = group.split(u"百")
-            s = filter(None, s)
+            s = list(filter(None, s))
             num = 0
             if len(s) == 1:
                 hundred = int(s[0])
@@ -115,7 +115,7 @@ class StringPreHandler:
         for m in match:
             group = m.group()
             s = group.split(u"千")
-            s = filter(None, s)
+            s = list(filter(None, s))
             num = 0
             if len(s) == 1:
                 thousand = int(s[0])

--- a/Test.py
+++ b/Test.py
@@ -34,6 +34,12 @@ print(res)
 res = tn.parse(target=u'7000万')
 print(res)
 
+res = tn.parse(target=u'7百')
+print(res)
+
+res = tn.parse(target=u'7千')
+print(res)
+
 #
 #
 #

--- a/Test.py
+++ b/Test.py
@@ -31,6 +31,9 @@ print(res)
 res = tn.parse(target=u'今年春分')
 print(res)
 
+res = tn.parse(target=u'7000万')
+print(res)
+
 #
 #
 #


### PR DESCRIPTION
fix bug：
  File "Time_NLP\StringPreHandler.py", line 136, in numberTranslator
    if len(s) == 1:
TypeError: object of type 'filter' has no len()

将filter(None, s)改为list(filter(None, s))

在Test.py中增加测试：
res = tn.parse(target=u'7000万')
print(res)