### PR TITLE
修复相对时间判定问题

### DIFF
--- a/TimeNormalizer.py
+++ b/TimeNormalizer.py
@@ -165,7 +165,7 @@ class TimeNormalizer:
             # 这里是一个类嵌套了一个类
             res.append(TimeUnit(temp[i], self, contextTp))
             # res[i].tp.tunit[3] = -1
-            contextTp = res[i].tp.copy()
+            contextTp = res[i].tp
             # print(self.nowTime.year)
             # print(contextTp.tunit)
         res = self.__filterTimeUnit(res)

--- a/TimeNormalizer.py
+++ b/TimeNormalizer.py
@@ -159,8 +159,8 @@ class TimeNormalizer:
         res = []
         # 时间上下文： 前一个识别出来的时间会是下一个时间的上下文，用于处理：周六3点到5点这样的多个时间的识别，第二个5点应识别到是周六的。
         contextTp = TimePoint()
-        print(self.timeBase)
-        print('temp',temp)
+        # print(self.timeBase)
+        # print('temp',temp)
         for i in range(0, rpointer):
             # 这里是一个类嵌套了一个类
             res.append(TimeUnit(temp[i], self, contextTp))

--- a/TimeNormalizer.py
+++ b/TimeNormalizer.py
@@ -165,7 +165,7 @@ class TimeNormalizer:
             # 这里是一个类嵌套了一个类
             res.append(TimeUnit(temp[i], self, contextTp))
             # res[i].tp.tunit[3] = -1
-            contextTp = res[i].tp
+            contextTp = res[i].tp.copy()
             # print(self.nowTime.year)
             # print(contextTp.tunit)
         res = self.__filterTimeUnit(res)

--- a/TimePoint.py
+++ b/TimePoint.py
@@ -13,3 +13,8 @@
 class TimePoint:
     def __init__(self):
         self.tunit = [-1, -1, -1, -1, -1, -1]
+
+    def copy(self):
+        new_instance = TimePoint()
+        new_instance.tunit = self.tunit.copy()
+        return new_instance

--- a/TimeUnit.py
+++ b/TimeUnit.py
@@ -720,7 +720,7 @@ class TimeUnit:
         :return:
         """
         # 这一块还是用了断言表达式
-        cur = arrow.get(self.normalizer.timeBase, "YYYY-M-D-H-m-s")
+        cur = arrow.get(self.normalizer.oldTimeBase, "YYYY-M-D-H-m-s")
         flag = [False, False, False]
 
         rule = u"前年"

--- a/TimeUnit.py
+++ b/TimeUnit.py
@@ -9,7 +9,6 @@
 
 import regex as re
 import arrow
-import copy
 from TimePoint import TimePoint
 from RangeTimeEnum import RangeTimeEnum
 
@@ -27,7 +26,7 @@ class TimeUnit:
         # print(exp_time)
         self.normalizer = normalizer
         self.tp = TimePoint()
-        self.tp_origin = contextTp
+        self.tp_origin = contextTp.copy()
         self.isFirstTimeSolveContext = True
         self.isMorning = False
         self.isAllDayTime = True
@@ -48,7 +47,6 @@ class TimeUnit:
         self.norm_setSpanRelated()
         self.norm_setHoliday()
         self.modifyTimeBase()
-        self.tp_origin.tunit = copy.deepcopy(self.tp.tunit)
 
         # 判断是时间点还是时间区间
         flag = True

--- a/TimeUnit.py
+++ b/TimeUnit.py
@@ -858,7 +858,7 @@ class TimeUnit:
             rule = u"上"
             pattern = re.compile(rule)
             match = pattern.findall(self.exp_time)
-            cur = cur.replace(weeks=-len(match), days=span)
+            cur = cur.shift(weeks=-len(match), days=span)
 
         rule = u"(?<=((?<!上)上(周|星期)))[1-7]?"
         pattern = re.compile(rule)
@@ -871,7 +871,7 @@ class TimeUnit:
                 week = 1
             week -= 1
             span = week - cur.weekday()
-            cur = cur.replace(weeks=-1, days=span)
+            cur = cur.shift(weeks=-1, days=span)
 
         rule = u"(?<=((?<!下)下(周|星期)))[1-7]?"
         pattern = re.compile(rule)

--- a/TimeUnit.py
+++ b/TimeUnit.py
@@ -884,7 +884,7 @@ class TimeUnit:
                 week = 1
             week -= 1
             span = week - cur.weekday()
-            cur = cur.replace(weeks=1, days=span)
+            cur = cur.shift(weeks=1, days=span)
 
         # 这里对下下下周的时间转换做出了改善
         rule = u"(?<=(下*下下(周|星期)))[1-7]?"
@@ -901,7 +901,7 @@ class TimeUnit:
             rule = u"下"
             pattern = re.compile(rule)
             match = pattern.findall(self.exp_time)
-            cur = cur.replace(weeks=len(match), days=span)
+            cur = cur.shift(weeks=len(match), days=span)
 
         rule = u"(?<=((?<!(上|下|个|[0-9]))(周|星期)))[1-7]"
         pattern = re.compile(rule)
@@ -914,7 +914,7 @@ class TimeUnit:
                 week = 1
             week -= 1
             span = week - cur.weekday()
-            cur = cur.replace(days=span)
+            cur = cur.shift(days=span)
             # 处理未来时间
             cur = self.preferFutureWeek(week, cur)
 


### PR DESCRIPTION
修改前：
「下周一到下下周一」的第二个相对时间会以第一个相对时间为基准，例如今天是 2020-04-05，输出为 `['2020-04-06 00:00:00', '2020-04-20 00:00:00']`

修改后：
第二个相对时间不会采用上下文，与第一个相对时间使用同一个 timeBase，例如今天是 2020-04-05，输出为 `['2020-04-06 00:00:00', '2020-04-13 00:00:00']`

**注意**：对代码不是特别了解，需要检查一下有没有对其他情况造成影响。